### PR TITLE
Redesign user profile template

### DIFF
--- a/assets/javascripts/custom_profile.js
+++ b/assets/javascripts/custom_profile.js
@@ -1,19 +1,22 @@
 Discourse.UserRoute.reopen({
   afterModel: function() {
     user = this.modelFor('user');
-    user.setProperties({"hummingbird": {"loaded": false}});
-    $.ajax("https://hummingbird.me/api/v1/users/" + user.get('username'), {
+    user.setProperties({hummingbird: {loaded: false}});
+    $.ajax("https://hummingbird.me/users/" + user.get('username'), {
       type: "GET",
       contentType: "application/json; charset=utf-8",
       success: function(data) {
+        var hb = data.user;
         user.setProperties({
-          "hummingbird": {
-            "loaded": true,
-            "coverImage": data.cover_image,
-            "online": data.online,
-            "following": data.following
+          hummingbird: {
+            loaded: true,
+            coverImageStyle: ('background-image: url("'+hb.cover_image_url+'")').htmlSafe(),
+            followingCount: hb.following_count,
+            follwerCount: hb.follower_count,
+            isPro: hb.is_pro,
+            bio: hb.bio
           }
-        })
+        });
       },
       xhrFields: {
         withCredentials: true

--- a/assets/javascripts/discourse/templates/user/user.js.handlebars
+++ b/assets/javascripts/discourse/templates/user/user.js.handlebars
@@ -1,248 +1,183 @@
+{{!-- BASED ON 5bf8c31af40eb62c5051ae76a0657644abcdb348 --}}
 {{#unless loading}}
-  {{!-- Hummingbird Profile Stuff --}}
   <div class="user-cover">
-    <img {{bind-attr src="hummingbird.coverImage"}} {{bind-attr class=":cover-photo hummingbird.loaded::cover-photo-loading"}}>
-    <div class="cover-overlay"></div>
+    <div {{bind-attr class=':cover-photo hummingbird.loaded::cover-photo-loading'}}
+         {{bind-attr style=hummingbird.coverImageStyle}}>
+      <div class="dark-overlay"></div>
+    </div>
   </div>
+
   <div class="container relative">
     <div class="row">
       <div class="user-cover-options">
-        <div class="col-md-10 user-wrapper">
+        <div class="col-sm-12 user-wrapper">
           <div class="col-sm-2 col-md-2 user-avatar clearfix">
             <div class="large-avatar">
-              {{bound-avatar model "huge"}}
-              {{#if hummingbird.loaded}}
-                <div class="online-box">
-                  <div {{bind-attr class=":online-indicator hummingbird.online:online:offline"}}></div>
-                </div>
+              {{bound-avatar model 'huge'}}
+            </div>
+          </div>
+          <div class="col-sm-12 col-md-10 no-padding account-wrapper">
+            <div class="account-info">
+              <div class="bio-wrapper">
+                <h2 class="username">
+                  {{username}}
+                  {{#if title}}
+                    <span class="profile-badge">{{title}}</span>
+                  {{/if}}
+                  {{#if model.isPro}}
+                    {{#link-to 'pro'}}<span class="profile-badge">pro</span>{{/link-to}}
+                  {{/if}}
+                </h2>
+                <p class="user-bio">
+                  {{hummingbird.bio}}
+                </p>
+              </div>
+            </div>
+            <div class="follow-widgets">
+              {{#if viewingSelf}}
+                {{#if can_edit}}
+                  {{#link-to 'preferences' class='btn btn-default btn-lg follow-button save'}}
+                    {{fa-icon 'cog'}}
+                    {{i18n 'user.preferences'}}
+                  {{/link-to}}
+                {{else}}
+                  <button class="btn btn-default btn-lg follow-button edit" {{action "toggleEditMenu" this}}>
+                    <i class="fa fa-pencil"></i> Edit
+                  </button>
+                {{/if}}
+              {{else}}
+                {{#if can_send_private_message_to_user}}
+                  <button class="btn btn-default btn-lg follow-button message" {{action 'composePrivateMessage' model}}>
+                    {{fa-icon 'envelope'}}
+                    {{i18n 'user.private_message'}}
+                  </button>
+                {{/else}}
+                {{#if currentUser.staff}}
+                  <a {{bind-attr href="adminPath"}} class="btn btn-default btn-lg follow-button">
+                    {{fa-icon 'wrench'}}
+                    {{i18n 'admin.user.show_admin_profile'}}
+                  </a>
+                {{/if}}
               {{/if}}
             </div>
           </div>
-          <div class="col-sm-12 col-md-10 account-info">
-            <h1 class="username">{{username}}</h1>
-            <ul class="inline-list clearfix">
-              <li>
-                <a href="javascript:void(0)" title="Coming soon!">
-                  <i class="icon-exchange">&nbsp;</i>
-                  Compare
-                </a>
-              </li>
-              <li>
-                <a href="javascript:void(0)" title="Coming soon!">
-                  <i class="icon-heart-empty">&nbsp;</i>
-                  Suggest
-                </a>
-              </li>
-              <li>
-                <a href="javascript:void(0)" title="Coming soon!">
-                  <i class="icon-envelope-alt">&nbsp;</i>
-                  Message
-                </a>
-              </li>
-            </ul>
-          </div>
         </div>
-        {{#if currentUser}}
-          {{#unless viewingSelf}}
-            {{#if hummingbird.loaded}}
-              <button class="btn btn-default btn-lg follow-button" type="button">
-                {{#if hummingbird.following}}
-                  Unfollow
-                {{else}}
-                  Follow
-                {{/if}}
-              </button>
-            {{/if}}
-          {{/unless}}
-        {{/if}}
-      </div> <!-- .user-cover-options -->
+      </div>
     </div>
   </div>
+
   <div class="profile-navigation">
     <div class="container">
       <div class="row">
         <ul class="inline-list clearfix">
           <li class="nav-link">
-            <a href="https://hummingbird.me/users/{{unbound username}}/feed">Activity Feed</a>
+            <a href="https://hummingbird.me/users/{{unbound username}}">Feed</a>
           </li>
           <li class="nav-link">
             <a href="https://hummingbird.me/users/{{unbound username}}/library">Library</a>
           </li>
-          <li class="nav-link active">
-            {{#link-to 'userActivity'}}Forums{{/link-to}}
+          <li class="nav-link">
+            <a href="https://hummingbird.me/users/{{unbound username}}/groups">Groups</a>
           </li>
-          <li class="nav-link dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0)">More</a>
-            <ul class="dropdown-menu profile-nav-drop">
-              <li><a href="https://hummingbird.me/users/{{unbound username}}/favorite_anime">Favorite Anime</a></li>
-              <li><a href="https://hummingbird.me/users/{{unbound username}}/followers">Followers</a></li>
-              <li><a href="https://hummingbird.me/users/{{unbound username}}/following">Following</a></li>
-              {{#if viewingSelf}}
-                <li><a href="https://hummingbird.me/users/edit">Preferences</a></li>
-              {{/if}}
-            </ul>
+          <li class="nav-link">
+            <a href="https://hummingbird.me/users/{{unbound username}}/reviews">Reviews</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://hummingbird.me/users/{{unbound username}}/following">
+              Following &middot; {{hummingbird.followingCount}}
+            </a>
+          </li>
+          <li class="nav-link">
+            <a href="https://hummingbird.me/users/{{unbound username}}/follwers">
+              Followers &middot; {{hummingbird.followersCount}}
+            </a>
+          </li>
+          <li class="nav-link">
+            <a href="https://forums.hummingbird.me/users/{{unbound username}}/activity" class="active">Forums</a>
           </li>
         </ul>
       </div>
     </div>
   </div>
-  {{!-- End Hummingbird Profile Stuff --}}
 
-  <div class="container">
-    <section class='user-main'>
-      <section {{bind-attr class="collapsedInfo :about profileBackground:has-background:no-background"}}  {{bind-attr style="profileBackground"}}>
-      <div class='staff-counters'>
-        {{#if number_of_flags_given}}
-          <div><span class="helpful-flags">{{number_of_flags_given}}</span>&nbsp;{{i18n 'user.staff_counters.flags_given'}}</div>
-        {{/if}}
-        {{#if number_of_flagged_posts}}
-          <div>
-            {{#link-to 'user.flaggedPosts' this}}
-              <span class="flagged-posts">{{number_of_flagged_posts}}</span>&nbsp;{{i18n 'user.staff_counters.flagged_posts'}}
-            {{/link-to}}
+  <div class="profile-content">
+    <div class="row">
+      <div class="secondary-info">
+        <div class="user-about-panel">
+          <div class="panel-heading">
+            <h3 class="panel-title"> About {{username}}</h3>
           </div>
-        {{/if}}
-        {{#if number_of_deleted_posts}}
-          <div>
-            {{#link-to 'user.deletedPosts' this}}
-              <span class="deleted-posts">{{number_of_deleted_posts}}</span>&nbsp;{{i18n 'user.staff_counters.deleted_posts'}}
-            {{/link-to}}
-          </div>
-        {{/if}}
-        {{#if number_of_suspensions}}
-          <div><span class="suspensions">{{number_of_suspensions}}</span>&nbsp;{{i18n 'user.staff_counters.suspensions'}}</div>
-        {{/if}}
-        {{#if number_of_warnings}}
-          <div><span class="warnings-received">{{number_of_warnings}}</span>&nbsp;{{i18n 'user.staff_counters.warnings_received'}}</div>
-        {{/if}}
-      </div>
-        <div class='profile-image'></div>
-        <div class='details'>
-          <div class='primary'>
-            {{bound-avatar model "huge"}}
-            <section class='controls'>
-              <ul>
-                {{#if can_send_private_message_to_user}}
-                <li>
-                  <a class='btn btn-primary right' {{action "composePrivateMessage" model}}>
-                    {{fa-icon "envelope"}}
-                    {{i18n 'user.private_message'}}
-                  </a>
-                </li>
-                {{/if}}
-                {{#if viewingSelf}}
-                  <li><a {{action "logout"}} class='btn btn-danger right'>{{fa-icon "sign-out"}}{{i18n 'user.log_out'}}</a></li>
-                {{/if}}
-                {{#if currentUser.staff}}
-                  <li><a {{bind-attr href="adminPath"}} class='btn right'>{{fa-icon "wrench"}}{{i18n 'admin.user.show_admin_profile'}}</a></li>
-                {{/if}}
-                {{#if can_edit}}
-                  <li>{{#link-to 'preferences' class="btn right"}}{{fa-icon "cog"}}{{i18n 'user.preferences'}}{{/link-to}}</li>
-                {{/if}}
-                {{#if canInviteToForum}}
-                  <li>{{#link-to 'user.invited' class="btn right"}}{{fa-icon "envelope-o"}}{{i18n 'user.invited.title'}}{{/link-to}}</li>
-                {{/if}}
-              </ul>
-            </section>
-
-            <div class="primary-textual">
-              <h1>{{username}} {{user-status model}}</h1>
-              <h2>{{name}}</h2>
-              {{#if title}}
-                <h3>{{title}}</h3>
-              {{/if}}
-              <h3>
-              {{#if location}}{{fa-icon "map-maker"}}{{location}}{{/if}}
-              {{#if websiteName}}
-                {{fa-icon "globe"}}
-                {{#if linkWebsite}}
-                  <a {{bind-attr href="website"}} rel="nofollow" target="_blank">{{websiteName}}</a>
-                {{else}}
-                  <span {{bind-attr title="website"}}>{{websiteName}}</span>
-                {{/if}}
-              {{/if}}
-              </h3>
-
-              <div class='bio'>
-                {{#if isSuspended}}
-                  <div class='suspended'>
-                    {{fa-icon "ban"}}
-                    <b>{{i18n 'user.suspended_notice' date=suspendedTillDate}}</b><br/>
-                    <b>{{i18n 'user.suspended_reason'}}</b> {{suspend_reason}}
-                  </div>
-                {{/if}}
-                {{{bio_cooked}}}
-              </div>
-
-              {{#if publicUserFields}}
-                <div class="public-user-fields">
-                  {{#each uf in publicUserFields}}
-                    {{#if uf.value}}
-                      <div class="public-user-field">
-                        <span class="user-field-name">{{uf.field.name}}</span>:
-                        <span class="user-field-value">{{uf.value}}</span>
-                      </div>
-                    {{/if}}
-                  {{/each}}
+          <div class="panel-body">
+            <p class="about">
+              {{#if isSuspended}}
+                <div class='suspended'>
+                  {{fa-icon "ban"}}
+                  <b>{{i18n 'user.suspended_notice' date=suspendedTillDate}}</b><br/>
+                  <b>{{i18n 'user.suspended_reason'}}</b> {{suspend_reason}}
                 </div>
               {{/if}}
-
-              {{plugin-outlet "user-profile-primary"}}
-
+              {{{bio_cooked}}}
+            </p>
+            <div class="user-interests">
+              <ul>
+                <li>
+                  {{#if location}}
+                  <div class="interest-icon"> {{fa-icon 'home'}}</div>
+                    <div class="interest"> Lives in <strong>{{location}}</strong></div>
+                  {{/if}}
+                </li>
+                <li>
+                  {{#if websiteName}}
+                    <div class="interest-icon"> {{fa-icon 'link'}}</div>
+                    <div class="interest">
+                      {{#if linkWebsite}}
+                        <a {{bind-attr href=website}} rel="nofollow" target="_blank">{{websiteName}}</a>
+                      {{else}}
+                        <span {{bind-attr title=website}}>{{websiteName}}</span>
+                    </div>
+                  {{/if}}
+                </li>
+              </ul>
             </div>
+            {{plugin-outlet "user-profile-primary"}}
           </div>
-          <div style='clear: both'></div>
-        </div>
-
-        <div class='secondary'>
-          <dl>
-            {{#if created_at}}
-              <dt>{{i18n 'user.created'}}</dt><dd>{{bound-date created_at}}</dd>
-            {{/if}}
+          <ul class="list-group">
             {{#if last_posted_at}}
-              <dt>{{i18n 'user.last_posted'}}</dt><dd>{{bound-date last_posted_at}}</dd>
+              <li class="list-group-item">
+                <strong>{{i18n 'user.last_posted'}}:</strong>
+                {{bound-date last_posted_at}}
+              </li>
             {{/if}}
             {{#if last_seen_at}}
-              <dt>{{i18n 'user.last_seen'}}</dt><dd>{{bound-date last_seen_at}}</dd>
+              <li class="list-group-item">
+                <strong>{{i18n 'user.last_seen'}}:</strong>
+                {{bound-date last_seen_at}}
+              </li>
             {{/if}}
-            {{#if invited_by}}
-              <dt>{{i18n 'user.invited_by'}}</dt><dd>{{#link-to 'user' invited_by}}{{invited_by.username}}{{/link-to}}</dd>
-            {{/if}}
-            <dt>{{i18n 'user.trust_level'}}</dt><dd>{{trustLevel.name}}</dd>
-            {{#if canCheckEmails}}
-              <dt>{{i18n 'user.email.title'}}</dt>
-              <dd {{bind-attr title="email"}}>
-                {{#if email}}
-                  {{email}}
-                {{else}}
-                  {{d-button action="checkEmail" actionParam=model icon="envelope-o" label="admin.users.check_email.text" class="btn-primary"}}
-                {{/if}}
-              </dd>
-            {{/if}}
+            <li class="list-group-item">
+              <strong>{{i18n 'user.trust_level'}}:</strong>
+              {{trustLevel.name}}
+            </li>
             {{#if custom_groups}}
-              <dt>{{i18n 'groups.title' count=custom_groups.length}}</dt>
-              <dd class='groups'>
+              <li class="list-group-item">
+                <strong>{{i18n 'groups.title' count=custom_groups.length}}:</strong>
                 {{#each group in custom_groups}}
                   <span>{{#link-to 'group' group class="group-link"}}{{group.name}}{{/link-to}}</span>
                 {{/each}}
-              </dd>
+              </li>
             {{/if}}
-            {{#if canDeleteUser}}
-              {{d-button action="adminDelete" icon="exclamation-triangle" label="user.admin_delete" class="btn-danger"}}
-            {{/if}}
-          </dl>
-          {{plugin-outlet "user-profile-secondary"}}
+          </ul>
         </div>
-      </section>
+        {{plugin-outlet "user-profile-secondary"}}
 
-      <section class='user-navigation'>
-        <ul class='action-list nav-stacked'>
-          {{activity-filter count=statsCountNonPM user=model userActionType=userActionType indexStream=indexStream}}
+        <ul class="list-group">
+          {{!-- TODO: reopen activity-filter class to restyle these --}}
+          {{activity-filter class="list-group-item" count=statsCountNonPM user=model userActionType=userActionType indexStream=indexStream}}
           {{#each stat in statsExcludingPms}}
-            {{activity-filter content=stat user=model userActionType=userActionType indexStream=indexStream}}
+            {{activity-filter class="list-group-item" content=stat user=model userActionType=userActionType indexStream=indexStream}}
           {{/each}}
           {{#if showBadges}}
-            {{#link-to 'user.badges' tagName="li"}}
+            {{#link-to 'user.badges' tagName="li" class="list-group-item"}}
               {{#link-to 'user.badges'}}
                 <i class='glyph fa fa-certificate'></i>
                 {{i18n 'badges.title'}}
@@ -250,53 +185,39 @@
               {{/link-to}}
             {{/link-to}}
           {{/if}}
-          {{#if canSeeNotificationHistory}}
-            {{#link-to 'user.notifications' tagName="li"}}
-              {{#link-to 'user.notifications'}}
-                <i class='glyph fa fa-comment'></i>
-                {{i18n 'user.notifications'}}
-                <span class='count'>({{notification_count}})</span>
-              {{/link-to}}
-            {{/link-to}}
-          {{/if}}
         </ul>
-
         {{#if canSeePrivateMessages}}
-          <h3>{{fa-icon "envelope"}} {{i18n 'user.private_messages'}}</h3>
-          <ul class='action-list nav-stacked'>
-            <li {{bind-attr class=":noGlyph privateMessagesActive:active"}}>
-              {{#link-to 'userPrivateMessages.index' model}}
+          <div class="user-about-panel">
+            <div class="panel-heading">
+              <h3 class="panel-title">{{i18n 'user.private_messages'}}</h3>
+            </div>
+            <div class='list-group'>
+              {{#link-to 'userPrivateMessages.index' model class="list-group-item"}}
                 {{i18n 'user.messages.all'}}
                 {{#if hasPMs}}<span class='count'>({{private_messages_stats.all}})</span>{{/if}}
               {{/link-to}}
-            </li>
-            <li {{bind-attr class=":noGlyph privateMessagesMineActive:active"}}>
-              {{#link-to 'userPrivateMessages.mine' model}}
+              {{#link-to 'userPrivateMessages.mine' model class="list-group-item"}}
                 {{i18n 'user.messages.mine'}}
                 {{#if hasStartedPMs}}<span class='count'>({{private_messages_stats.mine}})</span>{{/if}}
               {{/link-to}}
-            </li>
-            <li {{bind-attr class=":noGlyph privateMessagesUnreadActive:active"}}>
-              {{#link-to 'userPrivateMessages.unread' model}}
+              {{#link-to 'userPrivateMessages.unread' model class="list-group-item"}}
                 {{i18n 'user.messages.unread'}}
                 {{#if hasUnreadPMs}}<span class='badge-notification unread-private-messages'>{{private_messages_stats.unread}}</span>{{/if}}
               {{/link-to}}
-            </li>
-          </ul>
+            </div>
+          </div>
         {{/if}}
-
         {{#if viewingSelf}}
           <div class='user-archive'>
             {{d-button action="exportUserArchive" label="user.download_archive" icon="download"}}
           </div>
         {{/if}}
-      </section>
-
-      <section class='user-right'>
+      </div>
+      {{!-- Left column end --}}
+      {{!-- Right column start --}}
+      <div class='user-feed'>
         {{outlet}}
-      </section>
-
-    </section>
+      </div>
+    </div>
   </div>
-
 {{/unless}}


### PR DESCRIPTION
This is a complete rewrite of the entire user profile template to at least vaguely match the modern profile CSS.  It's kind of strange in many ways, and will probably require tweaking as we go, but it's a solid start.

Yes I'm sure it would be hard to merge in future changes from upstream.  Good thing I have no intention of merging it!  My plan is to diff the file in discourse from the SHA located on line 1 to the SHA we update to, and then manually copy the changes over.  No merge conflicts, no trouble.

That all being said, I haven't really tested this yet, because I don't have a local copy of Discourse right now.

Main changes:
 * Switching hb header to the new design
 * Moving buttons from the discourse header into the hb header
 * Removing discourse header
 * Adding the two-column wrappers from hb profiles
 * Adding an about box based on the hb profile one
 * Replacing sidebar navigation for profile with Bootstrap `panel` and `list-group` stuff