### PR TITLE
Fix forum profile not linking to activity feed

### DIFF
--- a/assets/javascripts/discourse/templates/user/user.js.handlebars
+++ b/assets/javascripts/discourse/templates/user/user.js.handlebars
@@ -63,7 +63,7 @@
       <div class="row">
         <ul class="inline-list clearfix">
           <li class="nav-link">
-            <a href="https://hummingbird.me/users/{{unbound username}}/feed">Activity Feed</a>
+            <a href="https://hummingbird.me/users/{{unbound username}}">Activity Feed</a>
           </li>
           <li class="nav-link">
             <a href="https://hummingbird.me/users/{{unbound username}}/library">Library</a>


### PR DESCRIPTION
Previously reported here: https://forums.hummingbird.me/t/forum-profiles-linking-back-to-my-dashboard/24063
